### PR TITLE
Support estimated hours parsing and storage for tickets

### DIFF
--- a/AIScrumMasterAgent.Tests/TicketEnricherTests.cs
+++ b/AIScrumMasterAgent.Tests/TicketEnricherTests.cs
@@ -89,4 +89,50 @@ public class TicketEnricherTests
         result.ShouldNotBeNull();
         result!.Id.ShouldBe(300);
     }
+
+    [Theory]
+    [InlineData("3-5h", 3.0)]
+    [InlineData("4-8h", 4.0)]
+    [InlineData("4h", 4.0)]
+    [InlineData("1.5-3h", 1.5)]
+    [InlineData("10h", 10.0)]
+    public void ParseEstimatedHours_ReturnsLowerBound(string input, double expected)
+    {
+        double? result = TicketEnricher.ParseEstimatedHours(input);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("unknown")]
+    public void ParseEstimatedHours_ReturnNullForMalformedOrMissingInput(string? input)
+    {
+        double? result = TicketEnricher.ParseEstimatedHours(input);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task EnrichAsync_SetsEstimatedHoursOnCreateRequest()
+    {
+        SprintPlanItem item = new("Do something", null, null, ItemKind.Implementation);
+        GeneratedTicket ticket = new("Do something", "Desc", ["AC"], "3-5h", ["Step"], "Task", ["tag"]);
+
+        _claudeMock.Setup(c => c.GenerateTicketAsync(item, null)).ReturnsAsync(ticket);
+        _devOpsMock.Setup(d => d.CreateWorkItemAsync("User Story", It.Is<CreateWorkItemRequest>(r => r.EstimatedHours == 3.0)))
+            .ReturnsAsync(new WorkItem { Id = 400, Title = "Do something", Url = "http://example.com/400" });
+        _devOpsMock.Setup(d => d.GetWorkItemAsync(20))
+            .ReturnsAsync(new WorkItem { Id = 20, Description = "Do something in plan" });
+
+        WorkItemResult? result = await CreateEnricher().EnrichAsync(20, item, null);
+
+        result.ShouldNotBeNull();
+        _devOpsMock.Verify(
+            d => d.CreateWorkItemAsync("User Story", It.Is<CreateWorkItemRequest>(r => r.EstimatedHours == 3.0)),
+            Times.Once);
+    }
 }

--- a/AIScrumMasterAgent/AIScrumMasterAgent.csproj
+++ b/AIScrumMasterAgent/AIScrumMasterAgent.csproj
@@ -10,6 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>AIScrumMasterAgent.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.5" />

--- a/AIScrumMasterAgent/Models/CreateWorkItemRequest.cs
+++ b/AIScrumMasterAgent/Models/CreateWorkItemRequest.cs
@@ -7,4 +7,5 @@ public class CreateWorkItemRequest
     public string? AreaPath { get; set; }
     public string? Tags { get; set; }
     public int? ParentId { get; set; }
+    public double? EstimatedHours { get; set; }
 }

--- a/AIScrumMasterAgent/Services/AzureDevOpsService.cs
+++ b/AIScrumMasterAgent/Services/AzureDevOpsService.cs
@@ -55,6 +55,9 @@ public class AzureDevOpsService(IHttpClientFactory httpClientFactory, AppConfig 
         if (!string.IsNullOrEmpty(request.Tags))
             patchOps.Add(new { op = "add", path = "/fields/System.Tags", value = request.Tags });
 
+        if (request.EstimatedHours.HasValue)
+            patchOps.Add(new { op = "add", path = "/fields/Microsoft.VSTS.Scheduling.OriginalEstimate", value = (object)request.EstimatedHours.Value });
+
         string json = JsonSerializer.Serialize(patchOps);
         StringContent content = new(json, Encoding.UTF8, "application/json-patch+json");
 

--- a/AIScrumMasterAgent/Services/TicketEnricher.cs
+++ b/AIScrumMasterAgent/Services/TicketEnricher.cs
@@ -1,5 +1,6 @@
 using AIScrumMasterAgent.Models;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace AIScrumMasterAgent.Services;
 
@@ -26,7 +27,8 @@ public class TicketEnricher(
         {
             Title = generatedTicket.Title,
             Description = description,
-            Tags = tags
+            Tags = tags,
+            EstimatedHours = ParseEstimatedHours(generatedTicket.EstimatedHours)
         };
 
         WorkItem created = await _devOpsService.CreateWorkItemAsync(
@@ -37,6 +39,19 @@ public class TicketEnricher(
         await UpdateSprintPlanDescriptionAsync(sprintPlanTicketId, item.Text, created.Id);
 
         return new WorkItemResult(created.Id, created.Title, created.Url);
+    }
+
+    internal static double? ParseEstimatedHours(string? estimatedHours)
+    {
+        if (string.IsNullOrWhiteSpace(estimatedHours))
+            return null;
+
+        Match match = Regex.Match(estimatedHours, @"^\s*(\d+(?:\.\d+)?)");
+        if (match.Success && double.TryParse(match.Groups[1].Value, System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture, out double result))
+            return result;
+
+        return null;
     }
 
     internal static string FormatDescription(GeneratedTicket ticket)


### PR DESCRIPTION
Added EstimatedHours to CreateWorkItemRequest and AzureDevOpsService. Implemented parsing logic in TicketEnricher and updated ticket creation to use parsed values. Added unit tests for parsing and ticket creation. Exposed internals to test assembly for improved testability.
fixes #2 