### PR TITLE
Copy IterationPath from sprint plan to new tickets

### DIFF
--- a/AIScrumMasterAgent.Tests/TicketEnricherTests.cs
+++ b/AIScrumMasterAgent.Tests/TicketEnricherTests.cs
@@ -135,4 +135,24 @@ public class TicketEnricherTests
             d => d.CreateWorkItemAsync("User Story", It.Is<CreateWorkItemRequest>(r => r.EstimatedHours == 3.0)),
             Times.Once);
     }
+
+    [Fact]
+    public async Task EnrichAsync_CopiesIterationPathFromSprintPlan()
+    {
+        SprintPlanItem item = new("Do something", null, null, ItemKind.Implementation);
+        GeneratedTicket ticket = new("Do something", "Desc", ["AC"], "3-5h", ["Step"], "Task", ["tag"]);
+
+        _claudeMock.Setup(c => c.GenerateTicketAsync(item, null)).ReturnsAsync(ticket);
+        _devOpsMock.Setup(d => d.CreateWorkItemAsync("User Story", It.Is<CreateWorkItemRequest>(r => r.IterationPath == "Some\\Iteration\\Path")))
+            .ReturnsAsync(new WorkItem { Id = 500, Title = "Do something", Url = "http://example.com/500" });
+        _devOpsMock.Setup(d => d.GetWorkItemAsync(30))
+            .ReturnsAsync(new WorkItem { Id = 30, Description = "Do something in plan", IterationPath = "Some\\Iteration\\Path" });
+
+        WorkItemResult? result = await CreateEnricher().EnrichAsync(30, item, null);
+
+        result.ShouldNotBeNull();
+        _devOpsMock.Verify(
+            d => d.CreateWorkItemAsync("User Story", It.Is<CreateWorkItemRequest>(r => r.IterationPath == "Some\\Iteration\\Path")),
+            Times.Once);
+    }
 }

--- a/AIScrumMasterAgent/Models/CreateWorkItemRequest.cs
+++ b/AIScrumMasterAgent/Models/CreateWorkItemRequest.cs
@@ -8,4 +8,5 @@ public class CreateWorkItemRequest
     public string? Tags { get; set; }
     public int? ParentId { get; set; }
     public double? EstimatedHours { get; set; }
+    public string? IterationPath { get; set; }
 }

--- a/AIScrumMasterAgent/Models/WorkItem.cs
+++ b/AIScrumMasterAgent/Models/WorkItem.cs
@@ -7,4 +7,5 @@ public class WorkItem
     public string Description { get; set; } = "";
     public string WorkItemType { get; set; } = "";
     public string Url { get; set; } = "";
+    public string IterationPath { get; set; } = "";
 }

--- a/AIScrumMasterAgent/Services/AzureDevOpsService.cs
+++ b/AIScrumMasterAgent/Services/AzureDevOpsService.cs
@@ -58,6 +58,9 @@ public class AzureDevOpsService(IHttpClientFactory httpClientFactory, AppConfig 
         if (request.EstimatedHours.HasValue)
             patchOps.Add(new { op = "add", path = "/fields/Microsoft.VSTS.Scheduling.OriginalEstimate", value = (object)request.EstimatedHours.Value });
 
+        if (!string.IsNullOrEmpty(request.IterationPath))
+            patchOps.Add(new { op = "add", path = "/fields/System.IterationPath", value = request.IterationPath });
+
         string json = JsonSerializer.Serialize(patchOps);
         StringContent content = new(json, Encoding.UTF8, "application/json-patch+json");
 
@@ -245,7 +248,8 @@ public class AzureDevOpsService(IHttpClientFactory httpClientFactory, AppConfig 
             Title = GetField("System.Title"),
             Description = GetField("System.Description"),
             WorkItemType = GetField("System.WorkItemType"),
-            Url = api.Url ?? ""
+            Url = api.Url ?? "",
+            IterationPath = GetField("System.IterationPath")
         };
     }
 

--- a/AIScrumMasterAgent/Services/TicketEnricher.cs
+++ b/AIScrumMasterAgent/Services/TicketEnricher.cs
@@ -18,6 +18,8 @@ public class TicketEnricher(
         if (item.ExistingTicketId.HasValue)
             return null;
 
+        WorkItem sprintPlan = await _devOpsService.GetWorkItemAsync(sprintPlanTicketId);
+
         GeneratedTicket generatedTicket = await _claudeService.GenerateTicketAsync(item, context);
 
         string description = FormatDescription(generatedTicket);
@@ -28,7 +30,8 @@ public class TicketEnricher(
             Title = generatedTicket.Title,
             Description = description,
             Tags = tags,
-            EstimatedHours = ParseEstimatedHours(generatedTicket.EstimatedHours)
+            EstimatedHours = ParseEstimatedHours(generatedTicket.EstimatedHours),
+            IterationPath = sprintPlan.IterationPath
         };
 
         WorkItem created = await _devOpsService.CreateWorkItemAsync(
@@ -36,7 +39,7 @@ public class TicketEnricher(
 
         await _devOpsService.AddChildLinkAsync(sprintPlanTicketId, created.Id);
 
-        await UpdateSprintPlanDescriptionAsync(sprintPlanTicketId, item.Text, created.Id);
+        await UpdateSprintPlanDescriptionAsync(sprintPlanTicketId, item.Text, created.Id, sprintPlan.Description);
 
         return new WorkItemResult(created.Id, created.Title, created.Url);
     }
@@ -70,11 +73,8 @@ public class TicketEnricher(
         return sb.ToString();
     }
 
-    private async Task UpdateSprintPlanDescriptionAsync(int sprintPlanTicketId, string itemText, int newTicketId)
+    private async Task UpdateSprintPlanDescriptionAsync(int sprintPlanTicketId, string itemText, int newTicketId, string currentDescription)
     {
-        WorkItem workItem = await _devOpsService.GetWorkItemAsync(sprintPlanTicketId);
-        string currentDescription = workItem.Description;
-
         // Replace the plain item text with the ticket-number-prefixed version
         string updatedDescription = currentDescription.Replace(
             itemText,


### PR DESCRIPTION
Copy IterationPath from sprint plan to new tickets

Added IterationPath support to CreateWorkItemRequest and WorkItem. AzureDevOpsService now handles IterationPath for create/retrieve. TicketEnricher.EnrichAsync copies IterationPath from sprint plan. Refactored UpdateSprintPlanDescriptionAsync to use passed description. Added unit test to verify IterationPath copying behavior.
fix #1 